### PR TITLE
Add github hitcount widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://ci.alysaa.net/job/GeyserUpdaterMain/job/main/badge/icon)](https://ci.alysaa.net/job/GeyserUpdaterMain/job/main/)
+[![HitCount](http://hits.dwyl.com/Konicai/GeyserUpdater.svg)](http://hits.dwyl.com/Konicai/GeyserUpdater)
 
 # GeyserUpdater
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://ci.alysaa.net/job/GeyserUpdaterMain/job/main/badge/icon)](https://ci.alysaa.net/job/GeyserUpdaterMain/job/main/)
-[![HitCount](http://hits.dwyl.com/Konicai/GeyserUpdater.svg)](http://hits.dwyl.com/Konicai/GeyserUpdater)
+[![HitCount](http://hits.dwyl.com/YHDiamond/GeyserUpdater.svg)](http://hits.dwyl.com/YHDiamond/GeyserUpdater)
 
 # GeyserUpdater
 


### PR DESCRIPTION
Displays the hitcount of this project using [this](http://hits.dwyl.io/).