### PR TITLE
Update restart script creation and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,17 +48,16 @@ therefore you will need to setup a restart script that the server can use (via /
 :restart
 java -Xms-X-G -Xmx-X-G -jar ServerSoftware.jar nogui
 Goto restart
-
 ```
 
 # Restart-Message:
 
-Restart-Message will only work if you have enabled Auto-Restart. when the update has been downloaded it will send a text to the players
-to warn them that the server is restarting. You can change this text!
+Restart-Message will only work if you have enabled Auto-Restart. When the update has been downloaded it will send a message to the players
+to warn them that the server is restarting. You can change this message!
 
 ## Usage
 
-After you ran the command or enabled auto updating, it will check the current running Geyser version. If it's outdated, it will automatically download the latest Geyser build. Changes will only take place once the server has been shutdown correctly and restarted. Do not kill (Hard shutdown) the server/proxy or the updater wont update Geyser!
+After you run the `/geyserupdate` command or enable auto updating, it will check the current running Geyser version. If it's outdated, it will automatically download the latest Geyser build. Changes will only take place once the server has been shutdown correctly and restarted. Do not kill (Hard shutdown) the server/proxy or the updater wont update Geyser!
 
 ## bStats
 [Spigot stats](https://bstats.org/plugin/bukkit/GeyserUpdater/10202)
@@ -95,8 +94,8 @@ After you ran the command or enabled auto updating, it will check the current ru
 
 The project is owned by:
 - Jens
-- YHDiamond
-Special thanks to rtm516 who helped us with basically everything. Without him this project wouldn't even have a readme.
-Note: This is NOT an official GeyserMC plugin. It is made to work with GeyserMC but it is not maintained or produced by GeyserMC. If you need support with this plugin, do not ask Geyser devs, and instead, go to our Discord server linked above.
+- YHDiamond  
 
- 
+Special thanks to rtm516 who helped us with basically everything. Without him this project wouldn't even have a readme.  
+
+Note: This is NOT an official GeyserMC plugin. It is made to work with GeyserMC but it is not maintained or produced by GeyserMC. If you need support with this plugin, do not ask Geyser devs, and instead, go to our Discord server linked above.

--- a/src/main/java/com/alysaa/geyserupdater/bungee/BungeeUpdater.java
+++ b/src/main/java/com/alysaa/geyserupdater/bungee/BungeeUpdater.java
@@ -6,7 +6,7 @@ import com.alysaa.geyserupdater.bungee.util.bstats.Metrics;
 import com.alysaa.geyserupdater.bungee.util.BungeeResourceUpdateChecker;
 import com.alysaa.geyserupdater.common.util.CheckBuildFile;
 import com.alysaa.geyserupdater.common.util.CheckBuildNum;
-import com.alysaa.geyserupdater.common.util.RestartScriptFactory;
+import com.alysaa.geyserupdater.common.util.ScriptCreator;
 
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.plugin.Plugin;
@@ -56,8 +56,9 @@ public final class BungeeUpdater extends Plugin {
             URI fileURI;
             fileURI = new URI(ProxyServer.class.getProtectionDomain().getCodeSource().getLocation().getPath());
             File jar = new File(fileURI.getPath());
-            // Tell the createScript method what the filename of the server jar is, and that bungee is being used.
-            RestartScriptFactory.createScript(jar.getName(), true);
+            // Tell the createScript method the name of the server jar
+            // and that a loop is necessary because bungee has no restart system.
+            ScriptCreator.createScript(jar.getName(), true);
         } catch (URISyntaxException | IOException e) {
             e.printStackTrace();
         }

--- a/src/main/java/com/alysaa/geyserupdater/bungee/BungeeUpdater.java
+++ b/src/main/java/com/alysaa/geyserupdater/bungee/BungeeUpdater.java
@@ -1,19 +1,23 @@
 package com.alysaa.geyserupdater.bungee;
 
-import com.alysaa.geyserupdater.bungee.util.Config;
 import com.alysaa.geyserupdater.bungee.command.GeyserCommand;
+import com.alysaa.geyserupdater.bungee.util.Config;
 import com.alysaa.geyserupdater.bungee.util.bstats.Metrics;
+import com.alysaa.geyserupdater.bungee.util.BungeeResourceUpdateChecker;
 import com.alysaa.geyserupdater.common.util.CheckBuildFile;
 import com.alysaa.geyserupdater.common.util.CheckBuildNum;
-import com.alysaa.geyserupdater.bungee.util.BungeeResourceUpdateChecker;
-import com.alysaa.geyserupdater.common.util.MakeScript;
+import com.alysaa.geyserupdater.common.util.RestartScriptFactory;
+
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.config.Configuration;
 import net.md_5.bungee.config.ConfigurationProvider;
 import net.md_5.bungee.config.YamlConfiguration;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
@@ -40,17 +44,20 @@ public final class BungeeUpdater extends Plugin {
         } catch (IOException e) {
             e.printStackTrace();
         }
+        // Enable File Checking here
         this.checkFile();
-        this.checkOS();
         ProxyServer.getInstance().getScheduler().schedule(this, this::versionCheck, 0, 30, TimeUnit.MINUTES);
+        // Make startup script
+        makeScriptFile();
     }
 
-    private void checkOS() {
+    private void makeScriptFile() {
         try {
             URI fileURI;
             fileURI = new URI(ProxyServer.class.getProtectionDomain().getCodeSource().getLocation().getPath());
             File jar = new File(fileURI.getPath());
-            MakeScript.createScript(jar.getName());
+            // Tell the createScript method what the filename of the server jar is, and that bungee is being used.
+            RestartScriptFactory.createScript(jar.getName(), true);
         } catch (URISyntaxException | IOException e) {
             e.printStackTrace();
         }

--- a/src/main/java/com/alysaa/geyserupdater/common/util/RestartScriptFactory.java
+++ b/src/main/java/com/alysaa/geyserupdater/common/util/RestartScriptFactory.java
@@ -1,16 +1,14 @@
 package com.alysaa.geyserupdater.common.util;
 
-import com.alysaa.geyserupdater.common.util.OSUtils;
-
-import java.io.*;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.lang.management.ManagementFactory;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
-public class MakeScript {
+public class RestartScriptFactory {
 
-    public static void createScript(String jarPath) throws IOException {
+    public static void createScript(String jarPath, boolean isBungee) throws IOException {
         File file;
         String extension;
         if (OSUtils.isWindows()) {
@@ -26,16 +24,21 @@ public class MakeScript {
             System.out.println("[GeyserUpdater] A custom restart script has been made for you, its located in the main server folder. you will need to edit this and also make sure you enable it in spigot.yml!");
             FileOutputStream fos = new FileOutputStream(file);
             DataOutputStream dos = new DataOutputStream(fos);
+
             if (OSUtils.isWindows()) {
                 dos.writeBytes("@echo off\n");
             } else if (OSUtils.isLinux() || OSUtils.isMac()) {
                 dos.writeBytes("#!/bin/sh\n");
             }
-            dos.writeBytes(":restart\n");
+            // The restart signal from Spigot is being used in the GeyserSpigotDownload class, which means that a loop in this script is not necessary for spigot.
+            // GeyserBungeeDownload can only use the stop signal, so a loop must be used to keep the script alive. This only supports Windows currently.
+            if (isBungee) {
+                dos.writeBytes(":restart\n");
+            }
             dos.writeBytes("java -Xmx" + ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax() / (1024 * 1024) + "M -jar "+ jarPath +" nogui\n");
-            dos.writeBytes("Goto restart\n");
+            if (isBungee) {
+                dos.writeBytes("Goto restart\n");
+            }
         }
     }
-
-
 }

--- a/src/main/java/com/alysaa/geyserupdater/common/util/ScriptCreator.java
+++ b/src/main/java/com/alysaa/geyserupdater/common/util/ScriptCreator.java
@@ -31,13 +31,21 @@ public class ScriptCreator {
                 dos.writeBytes("#!/bin/sh\n");
             }
             // The restart signal from Spigot is being used in the GeyserSpigotDownload class, which means that a loop in this script is not necessary for spigot.
-            // GeyserBungeeDownload can only use the stop signal, so a loop must be used to keep the script alive. This only supports Windows currently.
+            // GeyserBungeeDownload can only use the stop signal, so a loop must be used to keep the script alive.
             if (runLoop) {
-                dos.writeBytes(":restart\n");
+                if (OSUtils.isWindows()) {
+                    dos.writeBytes(":restart\n");
+                } else if (OSUtils.isLinux() || OSUtils.isMac()) {
+                    dos.writeBytes("while true; do\n");
+                }
             }
             dos.writeBytes("java -Xmx" + ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax() / (1024 * 1024) + "M -jar "+ jarPath +" nogui\n");
             if (runLoop) {
-                dos.writeBytes("Goto restart\n");
+                if (OSUtils.isWindows()) {
+                    dos.writeBytes("timeout 10 && Goto restart\n");
+                } else if (OSUtils.isLinux() || OSUtils.isMac()) {
+                    dos.writeBytes("echo \"Server stopped, restarting in 10 seconds!\"; sleep 10; done\n");
+                }
             }
         }
     }

--- a/src/main/java/com/alysaa/geyserupdater/common/util/ScriptCreator.java
+++ b/src/main/java/com/alysaa/geyserupdater/common/util/ScriptCreator.java
@@ -6,9 +6,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 
-public class RestartScriptFactory {
+public class ScriptCreator {
 
-    public static void createScript(String jarPath, boolean isBungee) throws IOException {
+    public static void createScript(String jarPath, boolean runLoop) throws IOException {
         File file;
         String extension;
         if (OSUtils.isWindows()) {
@@ -32,11 +32,11 @@ public class RestartScriptFactory {
             }
             // The restart signal from Spigot is being used in the GeyserSpigotDownload class, which means that a loop in this script is not necessary for spigot.
             // GeyserBungeeDownload can only use the stop signal, so a loop must be used to keep the script alive. This only supports Windows currently.
-            if (isBungee) {
+            if (runLoop) {
                 dos.writeBytes(":restart\n");
             }
             dos.writeBytes("java -Xmx" + ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax() / (1024 * 1024) + "M -jar "+ jarPath +" nogui\n");
-            if (isBungee) {
+            if (runLoop) {
                 dos.writeBytes("Goto restart\n");
             }
         }

--- a/src/main/java/com/alysaa/geyserupdater/spigot/SpigotUpdater.java
+++ b/src/main/java/com/alysaa/geyserupdater/spigot/SpigotUpdater.java
@@ -62,18 +62,21 @@ public class SpigotUpdater extends JavaPlugin {
 
     private void makeScriptFile() {
         FileConfiguration spigot = YamlConfiguration.loadConfiguration(new File(Bukkit.getServer().getWorldContainer(), "spigot.yml"));
-        if (spigot.getString("restart-script")) {
+        String scriptPath = spigot.getString("settings.restart-script");
+        File script = new File(scriptPath);
+        if (script.exists())
+            System.out.println("[GeyserUpdater] Has detected a restart script.");
+        else
             try {
-            URI fileURI;
-            fileURI = new URI(Bukkit.class.getProtectionDomain().getCodeSource().getLocation().getPath());
-            File jar = new File(fileURI.getPath());
-            // Tell the createScript method the name of the server jar
-            // and that a loop is not necessary because spigot has a restart system.
-            ScriptCreator.createScript(jar.getName(), false);
-        } catch (URISyntaxException | IOException e) {
+                URI fileURI;
+                fileURI = new URI(Bukkit.class.getProtectionDomain().getCodeSource().getLocation().getPath());
+                File jar = new File(fileURI.getPath());
+                // Tell the createScript method the name of the server jar
+                // and that a loop is not necessary because spigot has a restart system.
+                ScriptCreator.createScript(jar.getName(), false);
+            } catch (URISyntaxException | IOException e) {
                 e.printStackTrace();
             }
-        }
     }
 
     public void versionCheck() {

--- a/src/main/java/com/alysaa/geyserupdater/spigot/SpigotUpdater.java
+++ b/src/main/java/com/alysaa/geyserupdater/spigot/SpigotUpdater.java
@@ -64,9 +64,9 @@ public class SpigotUpdater extends JavaPlugin {
         FileConfiguration spigot = YamlConfiguration.loadConfiguration(new File(Bukkit.getServer().getWorldContainer(), "spigot.yml"));
         String scriptPath = spigot.getString("settings.restart-script");
         File script = new File(scriptPath);
-        if (script.exists())
+        if (script.exists()) {
             System.out.println("[GeyserUpdater] Has detected a restart script.");
-        else
+        } else {
             try {
                 URI fileURI;
                 fileURI = new URI(Bukkit.class.getProtectionDomain().getCodeSource().getLocation().getPath());
@@ -77,6 +77,7 @@ public class SpigotUpdater extends JavaPlugin {
             } catch (URISyntaxException | IOException e) {
                 e.printStackTrace();
             }
+        }
     }
 
     public void versionCheck() {

--- a/src/main/java/com/alysaa/geyserupdater/spigot/SpigotUpdater.java
+++ b/src/main/java/com/alysaa/geyserupdater/spigot/SpigotUpdater.java
@@ -4,7 +4,7 @@ import com.alysaa.geyserupdater.spigot.command.GeyserCommand;
 import com.alysaa.geyserupdater.spigot.util.SpigotResourceUpdateChecker;
 import com.alysaa.geyserupdater.common.util.CheckBuildFile;
 import com.alysaa.geyserupdater.common.util.CheckBuildNum;
-import com.alysaa.geyserupdater.common.util.RestartScriptFactory;
+import com.alysaa.geyserupdater.common.util.ScriptCreator;
 
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.InvalidConfigurationException;
@@ -65,8 +65,9 @@ public class SpigotUpdater extends JavaPlugin {
             URI fileURI;
             fileURI = new URI(Bukkit.class.getProtectionDomain().getCodeSource().getLocation().getPath());
             File jar = new File(fileURI.getPath());
-            // Tell the createScript method what the filename of the server jar is, and that bungee is not being used.
-            RestartScriptFactory.createScript(jar.getName(), false);
+            // Tell the createScript method the name of the server jar
+            // and that a loop is not necessary because spigot has a restart system.
+            ScriptCreator.createScript(jar.getName(), false);
         } catch (URISyntaxException | IOException e) {
             e.printStackTrace();
         }

--- a/src/main/java/com/alysaa/geyserupdater/spigot/SpigotUpdater.java
+++ b/src/main/java/com/alysaa/geyserupdater/spigot/SpigotUpdater.java
@@ -1,16 +1,18 @@
 package com.alysaa.geyserupdater.spigot;
 
+import com.alysaa.geyserupdater.spigot.command.GeyserCommand;
+import com.alysaa.geyserupdater.spigot.util.SpigotResourceUpdateChecker;
 import com.alysaa.geyserupdater.common.util.CheckBuildFile;
 import com.alysaa.geyserupdater.common.util.CheckBuildNum;
-import com.alysaa.geyserupdater.common.util.MakeScript;
-import com.alysaa.geyserupdater.spigot.util.SpigotResourceUpdateChecker;
-import com.alysaa.geyserupdater.spigot.command.GeyserCommand;
+import com.alysaa.geyserupdater.common.util.RestartScriptFactory;
+
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -55,19 +57,21 @@ public class SpigotUpdater extends JavaPlugin {
         // Logger for check update on GeyserUpdater
         versionCheck();
         // Make startup script
-        makeScript();
+        makeScriptFile();
     }
 
-    private void makeScript() {
+    private void makeScriptFile() {
         try {
             URI fileURI;
             fileURI = new URI(Bukkit.class.getProtectionDomain().getCodeSource().getLocation().getPath());
             File jar = new File(fileURI.getPath());
-            MakeScript.createScript(jar.getName());
+            // Tell the createScript method what the filename of the server jar is, and that bungee is not being used.
+            RestartScriptFactory.createScript(jar.getName(), false);
         } catch (URISyntaxException | IOException e) {
             e.printStackTrace();
         }
     }
+
     public void versionCheck() {
         Logger logger = this.getLogger();
         String pluginVersion = this.getDescription().getVersion();


### PR DESCRIPTION
- Optimize imports

- Change the script creation in BungeeUpdater.Java and SpigotUpdater.Java to be more similar and adjust some names to be more unique.

- Implements proper script creation for Spigot/Bungee on Mac/Windows/Linux. Spigot doesn't need a loop in the script, Bungee does. Nothing special.

- Squashed a readme change into this

Probably a handful of formatting and style mistakes, but the script creation performed correctly when I tested it on bungee and spigot.