### PR TITLE
Fixes to CheckSpigotRestart

### DIFF
--- a/src/main/java/com/alysaa/geyserupdater/bungee/BungeeUpdater.java
+++ b/src/main/java/com/alysaa/geyserupdater/bungee/BungeeUpdater.java
@@ -62,7 +62,7 @@ public final class BungeeUpdater extends Plugin {
                     e.printStackTrace();
                 }
             } else {
-                System.out.println("Your OS is not supported! We support Linux, Mac, and Windows for automatic script creation!");
+                System.out.println("[GeyserUpdater] Your OS is not supported! We support Linux, Mac, and Windows for automatic script creation!");
             }
         }
     }

--- a/src/main/java/com/alysaa/geyserupdater/bungee/BungeeUpdater.java
+++ b/src/main/java/com/alysaa/geyserupdater/bungee/BungeeUpdater.java
@@ -6,6 +6,7 @@ import com.alysaa.geyserupdater.bungee.util.bstats.Metrics;
 import com.alysaa.geyserupdater.bungee.util.BungeeResourceUpdateChecker;
 import com.alysaa.geyserupdater.common.util.CheckBuildFile;
 import com.alysaa.geyserupdater.common.util.CheckBuildNum;
+import com.alysaa.geyserupdater.common.util.OSUtils;
 import com.alysaa.geyserupdater.common.util.ScriptCreator;
 
 import net.md_5.bungee.api.ProxyServer;
@@ -53,11 +54,15 @@ public final class BungeeUpdater extends Plugin {
 
     private void makeScriptFile() {
         if (this.getConfiguration().getBoolean("Auto-Script-Generating")) {
-            try {
-            // Tell the createScript method that a loop is necessary because bungee has no restart system.
-            ScriptCreator.createScript(true);
-        } catch (IOException e) {
-                e.printStackTrace();
+            if (OSUtils.isWindows() || OSUtils.isLinux() || OSUtils.isMac()) {
+                try {
+                // Tell the createScript method that a loop is necessary because bungee has no restart system.
+                ScriptCreator.createScript(true);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            } else {
+                System.out.println("Your OS is not supported! We support Linux, Mac, and Windows for automatic script creation!");
             }
         }
     }

--- a/src/main/java/com/alysaa/geyserupdater/common/util/ScriptCreator.java
+++ b/src/main/java/com/alysaa/geyserupdater/common/util/ScriptCreator.java
@@ -17,7 +17,7 @@ public class ScriptCreator {
         } else if (OSUtils.isLinux() || OSUtils.isMac()) {
             extension = "sh";
         } else {
-            System.out.println("Your OS is not supported! We support Linux, Mac, and Windows for automatic script creation!");
+            System.out.println("[GeyserUpdater] Your OS is not supported! We support Linux, Mac, and Windows for automatic script creation!");
             return;
         }
         file = new File("ServerRestartScript." + extension);

--- a/src/main/java/com/alysaa/geyserupdater/common/util/ScriptCreator.java
+++ b/src/main/java/com/alysaa/geyserupdater/common/util/ScriptCreator.java
@@ -22,8 +22,6 @@ public class ScriptCreator {
         }
         file = new File("ServerRestartScript." + extension);
         if (!file.exists()) {
-            System.out.println("[GeyserUpdater] A custom restart script has been made for you.");
-            System.out.println("[GeyserUpdater] You will need to shutdown the server and use our provided restart script.");
             FileOutputStream fos = new FileOutputStream(file);
             DataOutputStream dos = new DataOutputStream(fos);
 
@@ -53,6 +51,10 @@ public class ScriptCreator {
                 } else if (OSUtils.isLinux() || OSUtils.isMac()) {
                     dos.writeBytes("echo \"Server stopped, restarting in 10 seconds!\"; sleep 10; done\n");
                 }
+            }
+            System.out.println("[GeyserUpdater] A custom restart script has been made for you.");
+            if (runLoop) {
+                System.out.println("[GeyserUpdater] You will need to shutdown the server and use our provided restart script.");
             }
         }
     }

--- a/src/main/java/com/alysaa/geyserupdater/common/util/ScriptCreator.java
+++ b/src/main/java/com/alysaa/geyserupdater/common/util/ScriptCreator.java
@@ -12,6 +12,7 @@ public class ScriptCreator {
     public static void createScript(boolean runLoop) throws IOException {
         File file;
         String extension;
+        // This method is only called
         if (OSUtils.isWindows()) {
             extension = "bat";
         } else if (OSUtils.isLinux() || OSUtils.isMac()) {

--- a/src/main/java/com/alysaa/geyserupdater/common/util/ScriptCreator.java
+++ b/src/main/java/com/alysaa/geyserupdater/common/util/ScriptCreator.java
@@ -12,7 +12,6 @@ public class ScriptCreator {
     public static void createScript(boolean runLoop) throws IOException {
         File file;
         String extension;
-        // This method is only called
         if (OSUtils.isWindows()) {
             extension = "bat";
         } else if (OSUtils.isLinux() || OSUtils.isMac()) {

--- a/src/main/java/com/alysaa/geyserupdater/spigot/SpigotUpdater.java
+++ b/src/main/java/com/alysaa/geyserupdater/spigot/SpigotUpdater.java
@@ -64,7 +64,7 @@ public class SpigotUpdater extends JavaPlugin {
                     e.printStackTrace();
                 }
             } else {
-                System.out.println("Your OS is not supported! We support Linux, Mac, and Windows for automatic script creation!");
+                System.out.println("[GeyserUpdater] Your OS is not supported! We support Linux, Mac, and Windows for automatic script creation!");
             }
         }
     }

--- a/src/main/java/com/alysaa/geyserupdater/spigot/SpigotUpdater.java
+++ b/src/main/java/com/alysaa/geyserupdater/spigot/SpigotUpdater.java
@@ -1,5 +1,6 @@
 package com.alysaa.geyserupdater.spigot;
 
+import com.alysaa.geyserupdater.common.util.OSUtils;
 import com.alysaa.geyserupdater.spigot.command.GeyserCommand;
 import com.alysaa.geyserupdater.spigot.util.SpigotResourceUpdateChecker;
 import com.alysaa.geyserupdater.common.util.CheckBuildFile;
@@ -56,10 +57,14 @@ public class SpigotUpdater extends JavaPlugin {
         // Check if a restart script already exists
         // We create one if it doesn't
         if (getConfig().getBoolean("Auto-Script-Generating")) {
-            try {
-                CheckSpigotRestart.checkYml();
-            } catch (Exception e) {
-                e.printStackTrace();
+            if (OSUtils.isWindows() || OSUtils.isLinux() || OSUtils.isMac()) {
+                try {
+                    CheckSpigotRestart.checkYml();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            } else {
+                System.out.println("Your OS is not supported! We support Linux, Mac, and Windows for automatic script creation!");
             }
         }
     }

--- a/src/main/java/com/alysaa/geyserupdater/spigot/util/CheckSpigotRestart.java
+++ b/src/main/java/com/alysaa/geyserupdater/spigot/util/CheckSpigotRestart.java
@@ -22,6 +22,7 @@ public class CheckSpigotRestart {
                 ScriptCreator.createScript(false);
             } catch (IOException e) {
                 e.printStackTrace();
+                return;
             }
             // Set the restart-script entry in spigot.yml to the one we just created
             String scriptName;
@@ -40,6 +41,7 @@ public class CheckSpigotRestart {
                 spigot.save("spigot.yml");
             } catch (IOException e) {
                 e.printStackTrace();
+                return;
             }
             System.out.println("[GeyserUpdater] Has set restart-script in spigot.yml to " + scriptName);
         }

--- a/src/main/java/com/alysaa/geyserupdater/spigot/util/CheckSpigotRestart.java
+++ b/src/main/java/com/alysaa/geyserupdater/spigot/util/CheckSpigotRestart.java
@@ -32,7 +32,7 @@ public class CheckSpigotRestart {
                 scriptName = "./ServerRestartScript.sh";
             }
             else {
-                System.out.println("Your OS is not supported for script checking!");
+                System.out.println("[GeyserUpdater] Your OS is not supported for script checking!");
                 return;
             }
             spigot.set("settings.restart-script", scriptName);
@@ -41,6 +41,7 @@ public class CheckSpigotRestart {
             } catch (IOException e) {
                 e.printStackTrace();
             }
+            System.out.println("[GeyserUpdater] Has set restart-script in spigot.yml to " + scriptName);
         }
     }
 }

--- a/src/main/java/com/alysaa/geyserupdater/spigot/util/CheckSpigotRestart.java
+++ b/src/main/java/com/alysaa/geyserupdater/spigot/util/CheckSpigotRestart.java
@@ -14,26 +14,30 @@ public class CheckSpigotRestart {
         FileConfiguration spigot = YamlConfiguration.loadConfiguration(new File(Bukkit.getServer().getWorldContainer(), "spigot.yml"));
         String scriptPath = spigot.getString("settings.restart-script");
         File script = new File(scriptPath);
-        String scriptName;
-        if (OSUtils.isWindows()) scriptName = "ServerRestartScript.bat";
-        else if (OSUtils.isLinux() || OSUtils.isMac()) scriptName = "./ServerRestartScript.sh";
-        else {
-            System.out.println("Your OS is not supported for script checking!");
-            return;
-        }
-        spigot = YamlConfiguration.loadConfiguration(new File(Bukkit.getServer().getWorldContainer(), "spigot.yml"));
-        spigot.set("settings.restart-script", scriptName);
-        try {
-            spigot.save("spigot.yml");
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        if (script.exists())
+        if (script.exists()) {
             System.out.println("[GeyserUpdater] Has detected a restart script.");
-        else {
+        } else {
             try {
                 // Tell the createScript method that a loop is not necessary because spigot has a restart system.
                 ScriptCreator.createScript(false);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            // Set the restart-script entry in spigot.yml to the one we just created
+            String scriptName;
+            if (OSUtils.isWindows()) {
+                scriptName = "ServerRestartScript.bat";
+            }
+            else if (OSUtils.isLinux() || OSUtils.isMac()) {
+                scriptName = "./ServerRestartScript.sh";
+            }
+            else {
+                System.out.println("Your OS is not supported for script checking!");
+                return;
+            }
+            spigot.set("settings.restart-script", scriptName);
+            try {
+                spigot.save("spigot.yml");
             } catch (IOException e) {
                 e.printStackTrace();
             }

--- a/src/main/java/com/alysaa/geyserupdater/spigot/util/CheckSpigotRestart.java
+++ b/src/main/java/com/alysaa/geyserupdater/spigot/util/CheckSpigotRestart.java
@@ -28,11 +28,9 @@ public class CheckSpigotRestart {
             String scriptName;
             if (OSUtils.isWindows()) {
                 scriptName = "ServerRestartScript.bat";
-            }
-            else if (OSUtils.isLinux() || OSUtils.isMac()) {
+            } else if (OSUtils.isLinux() || OSUtils.isMac()) {
                 scriptName = "./ServerRestartScript.sh";
-            }
-            else {
+            } else {
                 System.out.println("[GeyserUpdater] Your OS is not supported for script checking!");
                 return;
             }


### PR DESCRIPTION
- These changes stop the updater from changing the restart-script value in spigot.yml to ServerRestartScript.extension even if a preexisting script was already detected (based on the replaced value). 

- Add a message if the updater does change the value of restart-script

- Add [Geyser-Updater] to some messages that still use System.out.println

- Add *earlier* checks against unsupportd OS'. These ones will stop checkYml() or createScript() from ever being called if the OS is unsupported. The amount and location of the checks are messy so I'll probably come back to this, input would be gladly appreciated. 


tested on both linux and windows