### PR TITLE
Let the join listener use a cached result of CheckBuildFile

### DIFF
--- a/src/main/java/com/alysaa/geyserupdater/bungee/BungeeUpdater.java
+++ b/src/main/java/com/alysaa/geyserupdater/bungee/BungeeUpdater.java
@@ -48,7 +48,7 @@ public final class BungeeUpdater extends Plugin {
         // Player alert if a restart is required when they join
         getProxy().getPluginManager().registerListener(this, new BungeeJoinListener());
         // Check if downloaded Geyser file exists periodically
-        getProxy().getScheduler().schedule(this, () -> CheckBuildFile.checkSpigotFile(true), 30, 720, TimeUnit.MINUTES);
+        getProxy().getScheduler().schedule(this, () -> CheckBuildFile.checkBungeeFile(true), 30, 720, TimeUnit.MINUTES);
         // Check GeyserUpdater version periodically
         getProxy().getScheduler().schedule(this, this::versionCheck, 0, 24, TimeUnit.HOURS);
         // Make startup script

--- a/src/main/java/com/alysaa/geyserupdater/bungee/BungeeUpdater.java
+++ b/src/main/java/com/alysaa/geyserupdater/bungee/BungeeUpdater.java
@@ -48,7 +48,7 @@ public final class BungeeUpdater extends Plugin {
         // Player alert if a restart is required when they join
         getProxy().getPluginManager().registerListener(this, new BungeeJoinListener());
         // Check if downloaded Geyser file exists periodically
-        getProxy().getScheduler().schedule(this, CheckBuildFile::checkBungeeFile, 30, 720, TimeUnit.MINUTES);
+        getProxy().getScheduler().schedule(this, () -> CheckBuildFile.checkSpigotFile(true), 30, 720, TimeUnit.MINUTES);
         // Check GeyserUpdater version periodically
         getProxy().getScheduler().schedule(this, this::versionCheck, 0, 24, TimeUnit.HOURS);
         // Make startup script

--- a/src/main/java/com/alysaa/geyserupdater/bungee/util/BungeeJoinListener.java
+++ b/src/main/java/com/alysaa/geyserupdater/bungee/util/BungeeJoinListener.java
@@ -10,18 +10,8 @@ public class BungeeJoinListener implements Listener {
 
     @EventHandler
     public void onPostLogin(PostLoginEvent event) {
-        long currentTime = System.currentTimeMillis();
-        long elapsedTime = currentTime - CheckBuildFile.callTime;
-        if (elapsedTime > 30 * 60 * 1000)  {
-            // If the elapsedTime is greater than 30 minutes, the build file is checked directly.
-            if (CheckBuildFile.checkBungeeFile()) {
-                if (event.getPlayer().hasPermission("gupdater.geyserupdate")) {
-                    event.getPlayer().sendMessage(new TextComponent("[GeyserUpdater] New Geyser build has been downloaded! BungeeCord restart is required!"));
-                }
-            }
-        } else if (CheckBuildFile.cachedResult) {
-            // The only circumstance in which there is no cachedResult is when a build check hasn't occurred et.
-            // In such case, the callTime would be 0, so the elapsed time would be greater than 30 minutes.
+        // We allow a cached result of maximum age 30 minutes to be used
+        if (CheckBuildFile.checkBungeeFile(true)) {
             if (event.getPlayer().hasPermission("gupdater.geyserupdate")) {
                 event.getPlayer().sendMessage(new TextComponent("[GeyserUpdater] New Geyser build has been downloaded! BungeeCord restart is required!"));
             }

--- a/src/main/java/com/alysaa/geyserupdater/bungee/util/BungeeJoinListener.java
+++ b/src/main/java/com/alysaa/geyserupdater/bungee/util/BungeeJoinListener.java
@@ -1,5 +1,6 @@
 package com.alysaa.geyserupdater.bungee.util;
 
+import com.alysaa.geyserupdater.common.util.CheckBuildFile;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.event.PostLoginEvent;
 import net.md_5.bungee.api.plugin.Listener;
@@ -9,8 +10,21 @@ public class BungeeJoinListener implements Listener {
 
     @EventHandler
     public void onPostLogin(PostLoginEvent event) {
-        if (event.getPlayer().hasPermission("gupdater.geyserupdate")) {
-            event.getPlayer().sendMessage(new TextComponent("[GeyserUpdater] New Geyser build has been downloaded! BungeeCord restart is required!"));
+        long currentTime = System.currentTimeMillis();
+        long elapsedTime = currentTime - CheckBuildFile.callTime;
+        if (elapsedTime > 30 * 60 * 1000)  {
+            // If the elapsedTime is greater than 30 minutes, the build file is checked directly.
+            if (CheckBuildFile.checkBungeeFile()) {
+                if (event.getPlayer().hasPermission("gupdater.geyserupdate")) {
+                    event.getPlayer().sendMessage(new TextComponent("[GeyserUpdater] New Geyser build has been downloaded! BungeeCord restart is required!"));
+                }
+            }
+        } else if (CheckBuildFile.cachedResult) {
+            // The only circumstance in which there is no cachedResult is when a build check hasn't occurred et.
+            // In such case, the callTime would be 0, so the elapsed time would be greater than 30 minutes.
+            if (event.getPlayer().hasPermission("gupdater.geyserupdate")) {
+                event.getPlayer().sendMessage(new TextComponent("[GeyserUpdater] New Geyser build has been downloaded! BungeeCord restart is required!"));
+            }
         }
     }
 }

--- a/src/main/java/com/alysaa/geyserupdater/bungee/util/GeyserBungeeDownload.java
+++ b/src/main/java/com/alysaa/geyserupdater/bungee/util/GeyserBungeeDownload.java
@@ -56,7 +56,7 @@ public class GeyserBungeeDownload {
             }
         }
         // Check if the file was downloaded successfully
-        boolean downloadSuccess = CheckBuildFile.checkBungeeFile();
+        boolean downloadSuccess = CheckBuildFile.checkBungeeFile(false);
         // Restart the server if the option is enabled
         if (BungeeUpdater.getConfiguration().getBoolean("Auto-Restart-Server") && downloadSuccess) {
             BungeeUpdater.plugin.getLogger().info("The Server will restart in 10 Seconds!");

--- a/src/main/java/com/alysaa/geyserupdater/common/util/CheckBuildFile.java
+++ b/src/main/java/com/alysaa/geyserupdater/common/util/CheckBuildFile.java
@@ -9,13 +9,19 @@ import java.nio.file.Paths;
 public class CheckBuildFile {
 
 
-    // Epoch time at which either methods have been called last.
-    // Set to 0 first so the player join listener calls one of these classes if they haven't been called once before
-    public static long callTime = 0;
+    // Epoch time at which the last direct build file check occurred.
+    // Set to 0 first so a direct check always occurs first.
+    private static long callTime = 0;
 
-    public static boolean cachedResult;
+    private static boolean cachedResult;
 
-    public static boolean checkBungeeFile() {
+    public static boolean checkBungeeFile(boolean forPlayer) {
+        if (forPlayer) {
+            long elapsedTime = System.currentTimeMillis() - callTime;
+            if (elapsedTime < 30 * 60 * 1000) {
+                return cachedResult;
+            }
+        }
         callTime = System.currentTimeMillis();
         Path p = Paths.get("plugins/GeyserUpdater/BuildUpdate/Geyser-BungeeCord.jar");
         boolean exists = Files.exists(p);
@@ -27,7 +33,13 @@ public class CheckBuildFile {
         cachedResult = false;
         return false;
     }
-    public static boolean checkSpigotFile() {
+    public static boolean checkSpigotFile(boolean forPlayer) {
+        if (forPlayer) {
+            long elapsedTime = System.currentTimeMillis() - callTime;
+            if (elapsedTime < 30 * 60 * 1000) {
+                return cachedResult;
+            }
+        }
         callTime = System.currentTimeMillis();
         Path p = Paths.get("plugins/update/Geyser-Spigot.jar");
         boolean exists = Files.exists(p);

--- a/src/main/java/com/alysaa/geyserupdater/common/util/CheckBuildFile.java
+++ b/src/main/java/com/alysaa/geyserupdater/common/util/CheckBuildFile.java
@@ -8,22 +8,35 @@ import java.nio.file.Paths;
 
 public class CheckBuildFile {
 
+
+    // Epoch time at which either methods have been called last.
+    // Set to 0 first so the player join listener calls one of these classes if they haven't been called once before
+    public static long callTime = 0;
+
+    public static boolean cachedResult;
+
     public static boolean checkBungeeFile() {
+        callTime = System.currentTimeMillis();
         Path p = Paths.get("plugins/GeyserUpdater/BuildUpdate/Geyser-BungeeCord.jar");
         boolean exists = Files.exists(p);
         if (exists) {
             BungeeUpdater.plugin.getLogger().info("New Geyser build has been downloaded! BungeeCord restart is required!");
+            cachedResult = true;
             return true;
         }
+        cachedResult = false;
         return false;
     }
     public static boolean checkSpigotFile() {
+        callTime = System.currentTimeMillis();
         Path p = Paths.get("plugins/update/Geyser-Spigot.jar");
         boolean exists = Files.exists(p);
         if (exists) {
             SpigotUpdater.plugin.getLogger().info("New Geyser build has been downloaded! Server restart is required!");
+            cachedResult = true;
             return true;
         }
+        cachedResult = false;
         return false;
     }
 }

--- a/src/main/java/com/alysaa/geyserupdater/spigot/SpigotUpdater.java
+++ b/src/main/java/com/alysaa/geyserupdater/spigot/SpigotUpdater.java
@@ -115,7 +115,7 @@ public class SpigotUpdater extends JavaPlugin {
     private class StartTimer extends TimerTask {
         @Override
         public void run() {
-            CheckBuildFile.checkSpigotFile();
+            CheckBuildFile.checkSpigotFile(false);
         }
     }
     private class StartUpdate extends TimerTask {

--- a/src/main/java/com/alysaa/geyserupdater/spigot/util/GeyserSpigotDownload.java
+++ b/src/main/java/com/alysaa/geyserupdater/spigot/util/GeyserSpigotDownload.java
@@ -53,7 +53,7 @@ public class GeyserSpigotDownload {
                     }
                 }
                 // Check if the file was downloaded successfully
-                boolean downloadSuccess = CheckBuildFile.checkSpigotFile();
+                boolean downloadSuccess = CheckBuildFile.checkSpigotFile(false);
                 // Restart the server if the option is enabled
                 if (SpigotUpdater.plugin.getConfig().getBoolean("Auto-Restart-Server") && downloadSuccess) {
                     SpigotUpdater.plugin.getLogger().info("The Server will restart in 10 seconds!");

--- a/src/main/java/com/alysaa/geyserupdater/spigot/util/SpigotJoinListener.java
+++ b/src/main/java/com/alysaa/geyserupdater/spigot/util/SpigotJoinListener.java
@@ -1,5 +1,6 @@
 package com.alysaa.geyserupdater.spigot.util;
 
+import com.alysaa.geyserupdater.common.util.CheckBuildFile;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
@@ -8,8 +9,21 @@ public class SpigotJoinListener implements Listener {
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
-        if (event.getPlayer().hasPermission("gupdater.geyserupdate")) {
-            event.getPlayer().sendMessage("[GeyserUpdater] New Geyser build has been downloaded! Server restart is required!");
+        long currentTime = System.currentTimeMillis();
+        long elapsedTime = currentTime - CheckBuildFile.callTime;
+        if (elapsedTime > 30 * 60 * 1000)  {
+            // If the elapsedTime is greater than 30 minutes, the build file is checked directly.
+            if (CheckBuildFile.checkBungeeFile()) {
+                if (event.getPlayer().hasPermission("gupdater.geyserupdate")) {
+                    event.getPlayer().sendMessage("[GeyserUpdater] New Geyser build has been downloaded! Server restart is required!");
+                }
+            }
+        } else if (CheckBuildFile.cachedResult) {
+            // The only circumstance in which there is no cachedResult is when a build check hasn't occurred et.
+            // In such case, the callTime would be 0, so the elapsed time would be greater than 30 minutes.
+            if (event.getPlayer().hasPermission("gupdater.geyserupdate")) {
+                event.getPlayer().sendMessage("[GeyserUpdater] New Geyser build has been downloaded! Server restart is required!");
+            }
         }
     }
 }

--- a/src/main/java/com/alysaa/geyserupdater/spigot/util/SpigotJoinListener.java
+++ b/src/main/java/com/alysaa/geyserupdater/spigot/util/SpigotJoinListener.java
@@ -9,18 +9,8 @@ public class SpigotJoinListener implements Listener {
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
-        long currentTime = System.currentTimeMillis();
-        long elapsedTime = currentTime - CheckBuildFile.callTime;
-        if (elapsedTime > 30 * 60 * 1000)  {
-            // If the elapsedTime is greater than 30 minutes, the build file is checked directly.
-            if (CheckBuildFile.checkBungeeFile()) {
-                if (event.getPlayer().hasPermission("gupdater.geyserupdate")) {
-                    event.getPlayer().sendMessage("[GeyserUpdater] New Geyser build has been downloaded! Server restart is required!");
-                }
-            }
-        } else if (CheckBuildFile.cachedResult) {
-            // The only circumstance in which there is no cachedResult is when a build check hasn't occurred et.
-            // In such case, the callTime would be 0, so the elapsed time would be greater than 30 minutes.
+        // We allow a cached result of maximum age 30 minutes to be used
+        if (CheckBuildFile.checkSpigotFile(true)) {
             if (event.getPlayer().hasPermission("gupdater.geyserupdate")) {
                 event.getPlayer().sendMessage("[GeyserUpdater] New Geyser build has been downloaded! Server restart is required!");
             }


### PR DESCRIPTION
Also, the join listener now actually calls CheckBuildFile. 

We record the time at which the check method was last called, and we cache the result of any direct checks. 
We pass a boolean `forPlayer` set to true to the check method to indicate we are accepting cached results. I'm not fond of this name, however I chose it over something like `allowedCached` because a console log message isn't sent when a cached vale is used. Any input is appreciated. 

The time at which the method was last called is initially set to 0, which means a direct check always occurs first.
We use a direct check and refresh the cache if the cached result is older than 30 minutes. 

Only tested on Bungee, 